### PR TITLE
feat: Implement bottom tab navigation (TASK-002)

### DIFF
--- a/src/mobile/App.tsx
+++ b/src/mobile/App.tsx
@@ -1,13 +1,12 @@
 import { StatusBar } from 'expo-status-bar';
-import { Text, View } from 'react-native';
+import { NavigationContainer } from '@react-navigation/native';
+import { BottomTabNavigator } from './navigation/BottomTabNavigator';
 
 export default function App() {
   return (
-    <View className="flex-1 bg-white items-center justify-center">
-      <Text className="text-2xl font-bold text-gray-800">
-        Welcome to Remote Cursor
-      </Text>
-      <StatusBar style="auto" />
-    </View>
+    <NavigationContainer>
+      <BottomTabNavigator />
+      <StatusBar style="light" />
+    </NavigationContainer>
   );
 }

--- a/src/mobile/app/screens/DashboardScreen.tsx
+++ b/src/mobile/app/screens/DashboardScreen.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import { View, Text } from 'react-native';
+
+export const DashboardScreen = () => {
+  return (
+    <View className="flex-1 bg-[#1a1a2e] items-center justify-center">
+      <Text className="text-white text-xl">Dashboard</Text>
+    </View>
+  );
+};

--- a/src/mobile/app/screens/ScreenShareScreen.tsx
+++ b/src/mobile/app/screens/ScreenShareScreen.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import { View, Text } from 'react-native';
+
+export const ScreenShareScreen = () => {
+  return (
+    <View className="flex-1 bg-[#1a1a2e] items-center justify-center">
+      <Text className="text-white text-xl">Screen Share</Text>
+    </View>
+  );
+};

--- a/src/mobile/app/screens/SettingsScreen.tsx
+++ b/src/mobile/app/screens/SettingsScreen.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import { View, Text } from 'react-native';
+
+export const SettingsScreen = () => {
+  return (
+    <View className="flex-1 bg-[#1a1a2e] items-center justify-center">
+      <Text className="text-white text-xl">Settings</Text>
+    </View>
+  );
+};

--- a/src/mobile/app/screens/TerminalScreen.tsx
+++ b/src/mobile/app/screens/TerminalScreen.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import { View, Text } from 'react-native';
+
+export const TerminalScreen = () => {
+  return (
+    <View className="flex-1 bg-[#1a1a2e] items-center justify-center">
+      <Text className="text-white text-xl">Terminal</Text>
+    </View>
+  );
+};

--- a/src/mobile/navigation/BottomTabNavigator.tsx
+++ b/src/mobile/navigation/BottomTabNavigator.tsx
@@ -1,0 +1,58 @@
+import React from 'react';
+import { createBottomTabNavigator } from '@react-navigation/bottom-tabs';
+import { Ionicons } from '@expo/vector-icons';
+import { DashboardScreen } from '../app/screens/DashboardScreen';
+import { TerminalScreen } from '../app/screens/TerminalScreen';
+import { ScreenShareScreen } from '../app/screens/ScreenShareScreen';
+import { SettingsScreen } from '../app/screens/SettingsScreen';
+
+const Tab = createBottomTabNavigator();
+
+export const BottomTabNavigator = () => {
+  return (
+    <Tab.Navigator
+      screenOptions={({ route }) => ({
+        tabBarIcon: ({ focused, color, size }) => {
+          let iconName: keyof typeof Ionicons.glyphMap;
+
+          if (route.name === 'Dashboard') {
+            iconName = focused ? 'grid' : 'grid-outline';
+          } else if (route.name === 'Terminal') {
+            iconName = focused ? 'terminal' : 'terminal-outline';
+          } else if (route.name === 'ScreenShare') {
+            iconName = focused ? 'desktop' : 'desktop-outline';
+          } else if (route.name === 'Settings') {
+            iconName = focused ? 'settings' : 'settings-outline';
+          } else {
+            iconName = 'help-outline';
+          }
+
+          return <Ionicons name={iconName} size={size} color={color} />;
+        },
+        tabBarActiveTintColor: '#6c5ce7',
+        tabBarInactiveTintColor: '#8e8e93',
+        tabBarStyle: {
+          backgroundColor: '#1a1a2e',
+          borderTopColor: '#2d2d44',
+          borderTopWidth: 1,
+        },
+        headerStyle: {
+          backgroundColor: '#1a1a2e',
+        },
+        headerTintColor: '#ffffff',
+        headerTitleStyle: {
+          fontWeight: 'bold',
+        },
+      })}
+    >
+      <Tab.Screen name="Dashboard" component={DashboardScreen} />
+      <Tab.Screen name="Terminal" component={TerminalScreen} />
+      <Tab.Screen
+        name="ScreenShare"
+        component={ScreenShareScreen}
+        options={{ title: 'Screen Share' }}
+      />
+      <Tab.Screen name="Settings" component={SettingsScreen} />
+    </Tab.Navigator>
+  );
+};

--- a/src/mobile/package-lock.json
+++ b/src/mobile/package-lock.json
@@ -8,6 +8,7 @@
       "name": "mobile",
       "version": "1.0.0",
       "dependencies": {
+        "@expo/vector-icons": "^15.0.3",
         "@react-navigation/bottom-tabs": "^7.9.0",
         "@react-navigation/native": "^7.1.26",
         "expo": "~54.0.30",
@@ -2224,6 +2225,17 @@
       "resolved": "https://registry.npmjs.org/@expo/sudo-prompt/-/sudo-prompt-9.3.2.tgz",
       "integrity": "sha512-HHQigo3rQWKMDzYDLkubN5WQOYXJJE2eNqIQC2axC2iO3mHdwnIR7FgZVvHWtBwAdzBgAP0ECp8KqS8TiMKvgw==",
       "license": "MIT"
+    },
+    "node_modules/@expo/vector-icons": {
+      "version": "15.0.3",
+      "resolved": "https://registry.npmjs.org/@expo/vector-icons/-/vector-icons-15.0.3.tgz",
+      "integrity": "sha512-SBUyYKphmlfUBqxSfDdJ3jAdEVSALS2VUPOUyqn48oZmb2TL/O7t7/PQm5v4NQujYEPLPMTLn9KVw6H7twwbTA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "expo-font": ">=14.0.4",
+        "react": "*",
+        "react-native": "*"
+      }
     },
     "node_modules/@expo/ws-tunnel": {
       "version": "1.0.6",
@@ -4686,6 +4698,20 @@
         }
       }
     },
+    "node_modules/expo-font": {
+      "version": "14.0.10",
+      "resolved": "https://registry.npmjs.org/expo-font/-/expo-font-14.0.10.tgz",
+      "integrity": "sha512-UqyNaaLKRpj4pKAP4HZSLnuDQqueaO5tB1c/NWu5vh1/LF9ulItyyg2kF/IpeOp0DeOLk0GY0HrIXaKUMrwB+Q==",
+      "license": "MIT",
+      "dependencies": {
+        "fontfaceobserver": "^2.1.0"
+      },
+      "peerDependencies": {
+        "expo": "*",
+        "react": "*",
+        "react-native": "*"
+      }
+    },
     "node_modules/expo-modules-autolinking": {
       "version": "3.0.23",
       "resolved": "https://registry.npmjs.org/expo-modules-autolinking/-/expo-modules-autolinking-3.0.23.tgz",
@@ -4966,17 +4992,6 @@
         }
       }
     },
-    "node_modules/expo/node_modules/@expo/vector-icons": {
-      "version": "15.0.3",
-      "resolved": "https://registry.npmjs.org/@expo/vector-icons/-/vector-icons-15.0.3.tgz",
-      "integrity": "sha512-SBUyYKphmlfUBqxSfDdJ3jAdEVSALS2VUPOUyqn48oZmb2TL/O7t7/PQm5v4NQujYEPLPMTLn9KVw6H7twwbTA==",
-      "license": "MIT",
-      "peerDependencies": {
-        "expo-font": ">=14.0.4",
-        "react": "*",
-        "react-native": "*"
-      }
-    },
     "node_modules/expo/node_modules/ansi-styles": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
@@ -5120,20 +5135,6 @@
       "license": "MIT",
       "peerDependencies": {
         "expo": "*",
-        "react-native": "*"
-      }
-    },
-    "node_modules/expo/node_modules/expo-font": {
-      "version": "14.0.10",
-      "resolved": "https://registry.npmjs.org/expo-font/-/expo-font-14.0.10.tgz",
-      "integrity": "sha512-UqyNaaLKRpj4pKAP4HZSLnuDQqueaO5tB1c/NWu5vh1/LF9ulItyyg2kF/IpeOp0DeOLk0GY0HrIXaKUMrwB+Q==",
-      "license": "MIT",
-      "dependencies": {
-        "fontfaceobserver": "^2.1.0"
-      },
-      "peerDependencies": {
-        "expo": "*",
-        "react": "*",
         "react-native": "*"
       }
     },

--- a/src/mobile/package.json
+++ b/src/mobile/package.json
@@ -9,6 +9,7 @@
     "web": "expo start --web"
   },
   "dependencies": {
+    "@expo/vector-icons": "^15.0.3",
     "@react-navigation/bottom-tabs": "^7.9.0",
     "@react-navigation/native": "^7.1.26",
     "expo": "~54.0.30",


### PR DESCRIPTION
## Summary

Implemented bottom tab navigation with 4 main screens as specified in TASK-002:
- Created directory structure for screens, navigation, and components
- Implemented `BottomTabNavigator` with dark theme styling
- Added 4 placeholder screens: Dashboard, Terminal, Screen Share, and Settings
- Configured tab bar with purple accent color (#6c5ce7) and appropriate icons
- Integrated navigation into App.tsx with NavigationContainer

## Changes

- **Navigation**: Bottom tab navigator with 4 tabs (Dashboard, Terminal, Screen Share, Settings)
- **Screens**: Created placeholder screens with dark theme background
- **Styling**: Dark theme (#1a1a2e) with purple accent color for active tabs
- **Icons**: Ionicons for each tab (grid, terminal, desktop, settings)
- **Dependencies**: Added @react-navigation/bottom-tabs

## Test Plan

- [ ] App starts without errors
- [ ] All 4 tabs are visible in the bottom navigation
- [ ] Tapping each tab navigates to the corresponding screen
- [ ] Active tab is highlighted with purple color
- [ ] Dark theme is applied consistently
- [ ] Screen names are displayed correctly on each placeholder screen

🤖 Generated with [Claude Code](https://claude.com/claude-code)